### PR TITLE
Guard update and delete views for UserSchedule and add copy schedule feature

### DIFF
--- a/backend/app/views/main.py
+++ b/backend/app/views/main.py
@@ -78,7 +78,9 @@ def get_user_schedule_list(user_id):
 @require_jwt_token
 @require_same_user_id
 def delete_user_schedule(user_id, user_schedule_id):
-    user_schedule = UserSchedule.objects(id=user_schedule_id).first()
+    user_schedule = UserSchedule.objects(user_id=user_id, id=user_schedule_id).first()
+    if user_schedule is None:
+        return jsonify({'message': 'Schedule not found.'}), 404
     user_schedule.deleted = True
     user_schedule.save()
     return (jsonify(), 204)
@@ -89,7 +91,9 @@ def delete_user_schedule(user_id, user_schedule_id):
 @require_same_user_id
 def rename_user_schedule(user_id, user_schedule_id):
     data = request.json
-    user_schedule = UserSchedule.objects(id=user_schedule_id).first()
+    user_schedule = UserSchedule.objects(user_id=user_id, id=user_schedule_id).first()
+    if user_schedule is None:
+        return jsonify({'message': 'Schedule not found.'}), 404
     user_schedule.name = html.escape(data["name"])
     user_schedule.save()
     return (jsonify({
@@ -101,7 +105,9 @@ def rename_user_schedule(user_id, user_schedule_id):
 @require_jwt_token
 @require_same_user_id
 def edit_user_schedule(user_id, user_schedule_id):
-    user_schedule = UserSchedule.objects(id=user_schedule_id).first()
+    user_schedule = UserSchedule.objects(user_id=user_id, id=user_schedule_id).first()
+    if user_schedule is None:
+        return jsonify({'message': 'Schedule not found.'}), 404
     data = request.json
     user_schedule.clear_schedule_item()
     for editedScheduleItem in data['schedule_items']:

--- a/backend/app/views/main.py
+++ b/backend/app/views/main.py
@@ -105,11 +105,14 @@ def rename_user_schedule(user_id, user_schedule_id):
 @require_jwt_token
 @require_same_user_id
 def edit_user_schedule(user_id, user_schedule_id):
-    user_schedule = UserSchedule.objects(user_id=user_id, id=user_schedule_id).first()
-    # If the user is mismatched or the schedule is already deleted,
+    user_schedule = UserSchedule.objects(id=user_schedule_id).first()
+    # If the schedule doesn't exist or the user is mismatched,
     # create a new one with the same items.
     if user_schedule is None:
         user_schedule = UserSchedule(user_id=user_id)
+    elif str(user_schedule.user_id.id) != user_id:
+        name = f'{user_schedule.name} (copied)'
+        user_schedule = UserSchedule(user_id=user_id, name=name)
     data = request.json
     user_schedule.clear_schedule_item()
     for editedScheduleItem in data['schedule_items']:

--- a/backend/app/views/main.py
+++ b/backend/app/views/main.py
@@ -106,8 +106,10 @@ def rename_user_schedule(user_id, user_schedule_id):
 @require_same_user_id
 def edit_user_schedule(user_id, user_schedule_id):
     user_schedule = UserSchedule.objects(user_id=user_id, id=user_schedule_id).first()
+    # If the user is mismatched or the schedule is already deleted,
+    # create a new one with the same items.
     if user_schedule is None:
-        return jsonify({'message': 'Schedule not found.'}), 404
+        user_schedule = UserSchedule(user_id=user_id)
     data = request.json
     user_schedule.clear_schedule_item()
     for editedScheduleItem in data['schedule_items']:

--- a/frontend/src/containers/SelectedCourses/index.js
+++ b/frontend/src/containers/SelectedCourses/index.js
@@ -51,9 +51,12 @@ function SelectedCourses({ history, scheduleId, isEditing }) {
   async function updateSchedule() {
     dispatch(setLoading(true));
     try {
-      await makeAtLeastMs(putUpdateSchedule(auth.userId, scheduleId, transformSchedules(schedules)), 1000);
+      const { data } = await makeAtLeastMs(
+        putUpdateSchedule(auth.userId, scheduleId, transformSchedules(schedules)),
+        1000
+      );
       dispatch(clearSchedule());
-      history.push(`/jadwal/${scheduleId}`);
+      history.push(`/jadwal/${data.user_schedule.id}`);
     } catch (e) {
       // TODO: handle error
     }

--- a/frontend/src/containers/ViewSchedule/index.js
+++ b/frontend/src/containers/ViewSchedule/index.js
@@ -63,13 +63,11 @@ function ViewSchedule({ match }) {
                 {decodeHtmlEntity(schedule.name)}
               </ScheduleName>
             )}
-          {schedule.has_edit_access && (
-            <Link to={`/edit/${scheduleId}`} >
-              <Button intent="primary" onClick={() => null} >
-                Edit
-          </Button>
-            </Link>
-          )}
+          <Link to={`/edit/${scheduleId}`} >
+            <Button intent="primary" onClick={() => null} >
+              {schedule.has_edit_access ? 'Edit' : 'Copy'}
+            </Button>
+          </Link>
         </Container>
       )}
 


### PR DESCRIPTION
`@require_same_user_id` only checks whether the routes that contain `user_id` is accessed by the matching authenticated user. It's always true as long as the user is logged in and accessing the pages from the frontend app because the frontend only composes URLs with the authenticated user's ID. However, any user can update/delete any schedule as long as they know the schedule ID and are calling the views using their own user ID.

This PR fixes it by also checking whether the schedule object's `user_id` also matches the given `user_id` when querying the `UserSchedule` object. As a bonus, we can easily implement "Copy Schedule" feature by creating a new schedule in the edit view if the user attempts to edit another user's schedule (or their own schedule but has been deleted prior).